### PR TITLE
Implement TypeScript backend: LLM tracker, cost calculator, metrics endpoints, and DB schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "llm-monitor-backend",
+  "version": "1.0.0",
+  "description": "Node.js + TypeScript backend for LLM monitoring middleware",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.21.2",
+    "pg": "^8.13.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.10.2",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,16 @@
+import { Pool } from 'pg';
+
+/**
+ * Shared PostgreSQL connection pool used across middleware and routes.
+ */
+export const dbPool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.NODE_ENV === 'production' ? { rejectUnauthorized: false } : false
+});
+
+/**
+ * Gracefully closes pooled database connections.
+ */
+export async function closeDbPool(): Promise<void> {
+  await dbPool.end();
+}

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -1,0 +1,18 @@
+-- LLM usage tracking table for OpenAI middleware events.
+CREATE TABLE IF NOT EXISTS token_usage (
+  id BIGSERIAL PRIMARY KEY,
+  request_id TEXT,
+  user_id TEXT,
+  endpoint TEXT NOT NULL,
+  model TEXT NOT NULL,
+  input_tokens INTEGER NOT NULL CHECK (input_tokens >= 0),
+  output_tokens INTEGER NOT NULL CHECK (output_tokens >= 0),
+  total_tokens INTEGER NOT NULL CHECK (total_tokens >= 0),
+  latency_ms INTEGER NOT NULL CHECK (latency_ms >= 0),
+  cost_eur NUMERIC(14, 8) NOT NULL CHECK (cost_eur >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_token_usage_created_at ON token_usage (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_token_usage_model ON token_usage (model);
+CREATE INDEX IF NOT EXISTS idx_token_usage_user_id ON token_usage (user_id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,25 @@
+import 'dotenv/config';
+import express, { type NextFunction, type Request, type Response } from 'express';
+import { llmTracker } from './middleware/llmTracker';
+import { metricsRouter } from './routes/metrics';
+
+const app = express();
+app.use(express.json({ limit: '2mb' }));
+
+app.use(llmTracker());
+app.use('/metrics', metricsRouter);
+
+app.get('/health', (_req: Request, res: Response) => {
+  res.status(200).json({ status: 'ok' });
+});
+
+app.use((err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+  const message = err instanceof Error ? err.message : 'Unexpected error';
+  res.status(500).json({ error: message });
+});
+
+const port = Number(process.env.PORT ?? 3000);
+app.listen(port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`LLM monitor backend listening on port ${port}`);
+});

--- a/src/middleware/llmTracker.ts
+++ b/src/middleware/llmTracker.ts
@@ -1,0 +1,129 @@
+import type { NextFunction, Request, Response } from 'express';
+import { dbPool } from '../db/pool';
+import { calculateCostEur } from '../services/tokenCalculator';
+
+interface OpenAiUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+interface OpenAiResponse {
+  model?: string;
+  usage?: OpenAiUsage;
+}
+
+interface LlmTrackOptions {
+  /**
+   * Path prefix that represents proxied OpenAI requests.
+   * Default: /openai
+   */
+  openAiPathPrefix?: string;
+}
+
+/**
+ * Express middleware that tracks OpenAI request usage, latency and cost.
+ *
+ * This middleware expects to run on routes that proxy OpenAI calls. It reads:
+ * - model from request body or response body
+ * - token usage from response usage payload
+ * - latency from request start to response completion
+ *
+ * Results are persisted into `token_usage` table.
+ */
+export function llmTracker(options: LlmTrackOptions = {}) {
+  const pathPrefix = options.openAiPathPrefix ?? '/openai';
+
+  return async function trackLlmUsage(req: Request, res: Response, next: NextFunction): Promise<void> {
+    if (!req.path.startsWith(pathPrefix)) {
+      next();
+      return;
+    }
+
+    const startedAtMs = Date.now();
+    let capturedPayload: OpenAiResponse | null = null;
+
+    const originalJson = res.json.bind(res);
+    res.json = ((body: unknown) => {
+      if (body && typeof body === 'object') {
+        capturedPayload = body as OpenAiResponse;
+      }
+
+      return originalJson(body);
+    }) as Response['json'];
+
+    res.once('finish', async () => {
+      if (res.statusCode >= 400) {
+        return;
+      }
+
+      const model = extractModel(req.body, capturedPayload);
+      if (!model) {
+        return;
+      }
+
+      const promptTokens = capturedPayload?.usage?.prompt_tokens ?? 0;
+      const completionTokens = capturedPayload?.usage?.completion_tokens ?? 0;
+      const totalTokens = capturedPayload?.usage?.total_tokens ?? promptTokens + completionTokens;
+      const latencyMs = Date.now() - startedAtMs;
+
+      let costEur: number;
+      try {
+        costEur = calculateCostEur(model, promptTokens, completionTokens);
+      } catch {
+        // If model is unsupported, skip persisting rather than failing request lifecycle.
+        return;
+      }
+
+      try {
+        await dbPool.query(
+          `
+          INSERT INTO token_usage (
+            request_id,
+            user_id,
+            endpoint,
+            model,
+            input_tokens,
+            output_tokens,
+            total_tokens,
+            latency_ms,
+            cost_eur,
+            created_at
+          )
+          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW())
+          `,
+          [
+            req.headers['x-request-id'] ?? null,
+            req.headers['x-user-id'] ?? null,
+            req.originalUrl,
+            model,
+            promptTokens,
+            completionTokens,
+            totalTokens,
+            latencyMs,
+            costEur
+          ]
+        );
+      } catch (error) {
+        req.app.emit('error', error, req);
+      }
+    });
+
+    next();
+  };
+}
+
+function extractModel(requestBody: unknown, responseBody: OpenAiResponse | null): string | null {
+  if (requestBody && typeof requestBody === 'object' && 'model' in requestBody) {
+    const value = (requestBody as Record<string, unknown>).model;
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  if (typeof responseBody?.model === 'string' && responseBody.model.trim()) {
+    return responseBody.model.trim();
+  }
+
+  return null;
+}

--- a/src/routes/metrics.ts
+++ b/src/routes/metrics.ts
@@ -1,0 +1,124 @@
+import { Router, type Request, type Response } from 'express';
+import { dbPool } from '../db/pool';
+
+interface UsageMetricsRow {
+  calls: string;
+  input_tokens: string;
+  output_tokens: string;
+  total_tokens: string;
+}
+
+interface CostMetricsRow {
+  total_cost_eur: string;
+  avg_cost_eur: string;
+}
+
+interface LatencyMetricsRow {
+  avg_latency_ms: string;
+  p95_latency_ms: string;
+  p99_latency_ms: string;
+}
+
+/**
+ * Router exposing LLM monitoring metrics endpoints.
+ */
+export const metricsRouter = Router();
+
+/**
+ * GET /metrics/usage
+ * Returns aggregate usage from the last 24 hours.
+ */
+metricsRouter.get('/usage', async (_req: Request, res: Response) => {
+  try {
+    const result = await dbPool.query<UsageMetricsRow>(
+      `
+      SELECT
+        COUNT(*)::text AS calls,
+        COALESCE(SUM(input_tokens), 0)::text AS input_tokens,
+        COALESCE(SUM(output_tokens), 0)::text AS output_tokens,
+        COALESCE(SUM(total_tokens), 0)::text AS total_tokens
+      FROM token_usage
+      WHERE created_at >= NOW() - INTERVAL '24 hours'
+      `
+    );
+
+    const row = result.rows[0];
+
+    res.status(200).json({
+      window: '24h',
+      calls: Number(row.calls),
+      inputTokens: Number(row.input_tokens),
+      outputTokens: Number(row.output_tokens),
+      totalTokens: Number(row.total_tokens)
+    });
+  } catch (error) {
+    respondWithMetricsError(res, error);
+  }
+});
+
+/**
+ * GET /metrics/cost
+ * Returns total and average cost in EUR.
+ */
+metricsRouter.get('/cost', async (_req: Request, res: Response) => {
+  try {
+    const result = await dbPool.query<CostMetricsRow>(
+      `
+      SELECT
+        COALESCE(SUM(cost_eur), 0)::text AS total_cost_eur,
+        COALESCE(AVG(cost_eur), 0)::text AS avg_cost_eur
+      FROM token_usage
+      WHERE created_at >= NOW() - INTERVAL '24 hours'
+      `
+    );
+
+    const row = result.rows[0];
+
+    res.status(200).json({
+      currency: 'EUR',
+      totalCostEur: Number(row.total_cost_eur),
+      averageCostEur: Number(Number(row.avg_cost_eur).toFixed(8))
+    });
+  } catch (error) {
+    respondWithMetricsError(res, error);
+  }
+});
+
+/**
+ * GET /metrics/latency
+ * Returns latency aggregates in milliseconds.
+ */
+metricsRouter.get('/latency', async (_req: Request, res: Response) => {
+  try {
+    const result = await dbPool.query<LatencyMetricsRow>(
+      `
+      SELECT
+        COALESCE(AVG(latency_ms), 0)::text AS avg_latency_ms,
+        COALESCE(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY latency_ms), 0)::text AS p95_latency_ms,
+        COALESCE(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY latency_ms), 0)::text AS p99_latency_ms
+      FROM token_usage
+      WHERE created_at >= NOW() - INTERVAL '24 hours'
+      `
+    );
+
+    const row = result.rows[0];
+
+    res.status(200).json({
+      unit: 'ms',
+      averageLatencyMs: Number(Number(row.avg_latency_ms).toFixed(2)),
+      p95LatencyMs: Number(Number(row.p95_latency_ms).toFixed(2)),
+      p99LatencyMs: Number(Number(row.p99_latency_ms).toFixed(2))
+    });
+  } catch (error) {
+    respondWithMetricsError(res, error);
+  }
+});
+
+function respondWithMetricsError(res: Response, error: unknown): void {
+  const message = error instanceof Error ? error.message : 'Unknown metrics error';
+
+  res.status(500).json({
+    error: 'Failed to fetch metrics',
+    detail: message
+  });
+}

--- a/src/services/tokenCalculator.ts
+++ b/src/services/tokenCalculator.ts
@@ -1,0 +1,61 @@
+/**
+ * Supported priced model identifiers.
+ */
+export type SupportedModel = 'gpt-4o';
+
+/**
+ * Model pricing in EUR per token.
+ */
+export interface ModelPricing {
+  inputPerTokenEur: number;
+  outputPerTokenEur: number;
+}
+
+const MODEL_PRICING_EUR: Record<SupportedModel, ModelPricing> = {
+  'gpt-4o': {
+    inputPerTokenEur: 0.0000025,
+    outputPerTokenEur: 0.00001
+  }
+};
+
+/**
+ * Calculates request cost in EUR from token usage and model pricing.
+ *
+ * @param model - Model identifier (currently supports GPT-4o).
+ * @param inputTokens - Count of prompt/input tokens.
+ * @param outputTokens - Count of completion/output tokens.
+ * @returns Cost in EUR rounded to 8 decimal places.
+ */
+export function calculateCostEur(model: string, inputTokens: number, outputTokens: number): number {
+  if (!Number.isInteger(inputTokens) || inputTokens < 0) {
+    throw new Error('inputTokens must be a non-negative integer.');
+  }
+
+  if (!Number.isInteger(outputTokens) || outputTokens < 0) {
+    throw new Error('outputTokens must be a non-negative integer.');
+  }
+
+  const pricing = MODEL_PRICING_EUR[normalizeModel(model)];
+  const total = inputTokens * pricing.inputPerTokenEur + outputTokens * pricing.outputPerTokenEur;
+
+  return Number(total.toFixed(8));
+}
+
+/**
+ * Returns pricing details for a supported model.
+ *
+ * @param model - Model identifier.
+ */
+export function getModelPricing(model: string): ModelPricing {
+  return MODEL_PRICING_EUR[normalizeModel(model)];
+}
+
+function normalizeModel(model: string): SupportedModel {
+  const normalized = model.trim().toLowerCase();
+
+  if (normalized !== 'gpt-4o') {
+    throw new Error(`Unsupported model: ${model}. Supported models: gpt-4o.`);
+  }
+
+  return normalized;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "lib": ["ES2022"],
+    "moduleResolution": "Node",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
### Motivation
- Provide production-quality middleware to observe OpenAI-proxied calls by capturing model, input/output token counts, latency and cost in EUR for billing and monitoring. 
- Expose simple REST metrics for usage, cost and latency to enable dashboards and alerts for the last 24h. 
- Persist observations to PostgreSQL with a safe schema and connection pooling. 

### Description
- Add project configuration and scripts with `package.json` and `tsconfig.json` and TypeScript dev tooling (`build`, `dev`, `typecheck`).
- Provide a shared DB pool in `src/db/pool.ts` and a PostgreSQL schema `src/db/schema.sql` that defines the `token_usage` table and indexes. 
- Implement `src/services/tokenCalculator.ts` with strict validation and GPT-4o pricing in EUR (`input: €0.0000025` per token, `output: €0.000010` per token) exposed via `calculateCostEur` and `getModelPricing`. 
- Implement `src/middleware/llmTracker.ts` Express middleware that intercepts proxied OpenAI requests, extracts model and usage from request/response payloads, measures latency, calculates cost with `calculateCostEur`, and inserts records into `token_usage` while failing safely if the model is unsupported or DB errors occur. 
- Implement `src/routes/metrics.ts` with endpoints `GET /metrics/usage`, `GET /metrics/cost`, and `GET /metrics/latency` that return 24-hour aggregates (counts, token sums, total/avg cost in EUR, avg/p95/p99 latency). 
- Add a minimal bootstrap server in `src/index.ts` that wires the middleware and metrics router and includes a `/health` endpoint and centralized error handler. 

### Testing
- Attempted to install dependencies with `npm install`, but the run failed due to a registry policy 403 error in this environment and therefore no further automated test (build/typecheck) could be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c83d6e43688321916893e588ce580d)